### PR TITLE
Fix the path to LAVA_IMAGE_TMPDIR

### DIFF
--- a/debian/lava-dispatcher.conf
+++ b/debian/lava-dispatcher.conf
@@ -7,7 +7,7 @@ LAVA_SERVER_IP = 192.168.1.10
 LAVA_PROXY = 
 
 # Location for rootfs/boot tarballs extracted from images
-LAVA_IMAGE_TMPDIR = /var/lib/lava/dispatcher/tmp
+LAVA_IMAGE_TMPDIR = /var/lib/lava/dispatcher/images/tmp
 
 # URL where LAVA_IMAGE_TMPDIR can be accessed remotely
 LAVA_IMAGE_URL = http://%(LAVA_SERVER_IP)s/images/tmp


### PR DESCRIPTION
/var/lib/lava/dispatcher/tmp doesn't actually exist when the install finishes, so I think this is just a typo. Lets use /var/lib/lava/dispatcher/images/tmp instead.
