### PR TITLE
Minimal lxc version requirement / dependency >= 1:2.0.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Recommends: ntp, git, kpartx, tftpd-hpa, openbsd-inetd,
  qemu-system-x86 (>= 2.0.0) [amd64 i386],
  qemu-system-arm (>= 2.0.0) [armhf arm64], qemu-system-aarch64 (>= 2.0.0) [arm64],
  libguestfs-tools [amd64 i386], nfs-kernel-server, rpcbind,
- python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.0),
+ python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.6),
  bridge-utils, rsync, sshfs
 Suggests: bzr
 Description: Linaro Automated Validation Architecture dispatcher

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Vcs-Browser: https://github.com/Linaro/pkg-lava-dispatcher
 Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, lsb-base (>= 4), python-serial (>= 2.6), python-setuptools,
- python-daemon, python-guestfs, parted, tar (>= 1.27),
+ python-daemon, python-guestfs, python-pyudev, parted, tar (>= 1.27),
  ser2net, sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle


### PR DESCRIPTION
This solves issues seen with Debian lxc template.