### PR TITLE
Bump lxc version to 2.0.7 - to get latest changes to templates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Recommends: ntp, git, kpartx, tftpd-hpa, openbsd-inetd, ser2net,
  qemu-system-x86 (>= 2.0.0) [amd64 i386],
  qemu-system-arm (>= 2.0.0) [armhf arm64], qemu-system-aarch64 (>= 2.0.0) [arm64],
  libguestfs-tools [amd64 i386], nfs-kernel-server, rpcbind,
- python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.6),
+ python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.7),
  bridge-utils, rsync, sshfs, dfu-util
 Suggests: apache2, bzr
 Description: Linaro Automated Validation Architecture dispatcher


### PR DESCRIPTION
Required to support ubuntu templates.