### PR TITLE
Set minimal debootstrap version to 1.0.86 to get latest scripts.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Recommends: ntp, git, kpartx, tftpd-hpa, openbsd-inetd, ser2net,
  qemu-system-arm (>= 2.0.0) [armhf arm64], qemu-system-aarch64 (>= 2.0.0) [arm64],
  libguestfs-tools [amd64 i386], nfs-kernel-server, rpcbind,
  python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.7),
- bridge-utils, rsync, sshfs, dfu-util
+ debootstrap (>= 1.0.86), bridge-utils, rsync, sshfs, dfu-util
 Suggests: apache2, bzr
 Description: Linaro Automated Validation Architecture dispatcher
  LAVA is a continuous integration system for deploying operating


### PR DESCRIPTION
Provides latest ubuntu version scripts.