### PR TITLE
Add python-setproctitle to depends rather than recommends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, lsb-base (>= 4), python-serial (>= 2.6), python-setuptools,
  python-daemon, python-guestfs, parted, tar (>= 1.27),
- sudo, telnet, ${python:Depends}, ${misc:Depends}
+ python-setproctitle, sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle
 Replaces: python-linaro-dashboard-bundle
@@ -29,7 +29,7 @@ Recommends: ntp, git, kpartx, tftpd-hpa, openbsd-inetd, ser2net,
  qemu-system-x86 (>= 2.8.0) [amd64 i386],
  qemu-system-arm (>= 2.8.0) [amd64 armhf arm64],
  libguestfs-tools [amd64 i386], nfs-kernel-server, rpcbind,
- python-setproctitle, u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.7),
+ u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.7),
  debootstrap (>= 1.0.86), bridge-utils, rsync, sshfs, dfu-util
 Suggests: apache2, bzr, android-tools-fsutils | img2simg
 Description: Linaro Automated Validation Architecture dispatcher

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, lsb-base (>= 4), python-serial (>= 2.6), python-setuptools,
  python-daemon, python-guestfs, parted, tar (>= 1.27),
- python-setproctitle, sudo, telnet, ${python:Depends}, ${misc:Depends}
+ sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle
 Replaces: python-linaro-dashboard-bundle

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -9,3 +9,4 @@ netifaces python-netifaces; PEP386
 nose python-nose; PEP386
 pyzmq python-zmq; PEP386
 pyudev python-pyudev; PEP386
+setproctitle python-setproctitle; PEP386


### PR DESCRIPTION
This is required based on the introduction of lava-run.