### PR TITLE
Drop share/lava_lxc_device_add.py to /usr/share/lava-dispatcher/

### DIFF
--- a/debian/lava-dispatcher.install
+++ b/debian/lava-dispatcher.install
@@ -1,4 +1,5 @@
 debian/lava-dispatcher.conf ./usr/share/lava-dispatcher/
 share/create_certificate.py ./usr/share/lava-dispatcher/
 share/apache2/lava-dispatcher.conf ./usr/share/lava-dispatcher/apache2/
+share/lava_lxc_device_add.py ./usr/share/lava-dispatcher/
 etc/lava-slave ./usr/share/lava-dispatcher/


### PR DESCRIPTION
Will be required by https://review.linaro.org/#/c/21065/ for installing script properly to /usr/share/lava-dispatcher/