### PR TITLE
Add python-magic to depends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Vcs-Browser: https://github.com/Linaro/pkg-lava-dispatcher
 Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, lsb-base (>= 4), python-serial (>= 2.6), python-setuptools,
- python-daemon, python-guestfs, parted, tar (>= 1.27), python-magic (>= 5.30),
+ python-daemon, python-guestfs, parted, tar (>= 1.27),
  sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Vcs-Browser: https://github.com/Linaro/pkg-lava-dispatcher
 Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, lsb-base (>= 4), python-serial (>= 2.6), python-setuptools,
- python-daemon, python-guestfs, parted, tar (>= 1.27),
+ python-daemon, python-guestfs, parted, tar (>= 1.27), python-magic (>= 5.30),
  sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -10,3 +10,5 @@ nose python-nose; PEP386
 pyzmq python-zmq; PEP386
 pyudev python-pyudev; PEP386
 setproctitle python-setproctitle; PEP386
+pytz python-tz; PEP386
+file-magic python-magic; PEP386


### PR DESCRIPTION
python-magic from Debian stretch is different from what is available in pypi - https://pypi.python.org/pypi/python-magic (hence do not put this dependency in setup.py)