### PR TITLE
Set minimal python-guestfs and libguestfs-tools version to 1.32.7

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Vcs-Browser: https://github.com/Linaro/pkg-lava-dispatcher
 Package: lava-dispatcher
 Architecture: amd64 arm64 armhf i386 mipsel powerpc ppc64el s390x ppc64
 Depends: file, systemd-sysv, python-serial (>= 2.6), python-setuptools,
- python-guestfs, tar (>= 1.27),
+ python-guestfs (>= 1.32.7), tar (>= 1.27),
  sudo, telnet, ${python:Depends}, ${misc:Depends}
 Conflicts: python-linaro-dashboard-bundle
 Provides: python-linaro-dashboard-bundle
@@ -25,7 +25,7 @@ Multi-Arch: foreign
 Recommends: ntp, git, tftpd-hpa, openbsd-inetd, ser2net,
  qemu-system-x86 (>= 2.8.0) [amd64 i386],
  qemu-system-arm (>= 2.8.0) [amd64 armhf arm64],
- libguestfs-tools [amd64 i386], nfs-kernel-server, rpcbind,
+ libguestfs-tools (1.32.7) [amd64 i386], nfs-kernel-server, rpcbind,
  u-boot-tools, unzip, xz-utils, lxc (>= 1:2.0.7),
  debootstrap (>= 1.0.86), bridge-utils, rsync, sshfs, dfu-util
 Suggests: apache2, bzr, android-tools-fsutils | img2simg


### PR DESCRIPTION
See https://projects.linaro.org/browse/LAVA-1193 for details.